### PR TITLE
Auto label node PR's

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const subSystemLabels = {
+  'c++': /^src\//
+}
+
+const rxTests = /^test\//
+
+function resolveLabels (filepathsChanged) {
+  if (isOnly(rxTests, filepathsChanged)) {
+    return ['test']
+  }
+
+  return matchBySubSystemRegex(filepathsChanged)
+}
+
+function isOnly (regexToMatch, filepathsChanged) {
+  return filepathsChanged.every((filepath) => regexToMatch.test(filepath))
+}
+
+function matchBySubSystemRegex (filepathsChanged) {
+  // by putting matched labels into a map, we avoid duplicate labels
+  const labelsMap = filepathsChanged.reduce((map, filepath) => {
+    const mappedSubSystem = mappedSubSystemForFile(filepath)
+
+    if (mappedSubSystem) {
+      map[mappedSubSystem] = true
+    }
+
+    return map
+  }, {})
+
+  return Object.keys(labelsMap)
+}
+
+function mappedSubSystemForFile (filepath) {
+  return Object.keys(subSystemLabels).find((labelName) => {
+    const rxForLabel = subSystemLabels[labelName]
+
+    return rxForLabel.test(filepath) ? labelName : undefined
+  })
+}
+
+exports.resolveLabels = resolveLabels

--- a/lib/node-repo.js
+++ b/lib/node-repo.js
@@ -1,0 +1,70 @@
+'use strict'
+
+const githubClient = require('./github-client')
+
+const resolveLabels = require('./node-labels').resolveLabels
+
+function resolveLabelsThenUpdatePr (options) {
+  githubClient.pullRequests.getFiles({
+    user: options.owner,
+    repo: options.repo,
+    number: options.prId
+  }, (err, res) => {
+    if (err) {
+      return console.error(`! ${prInfoStr(options)} Error retrieving files`, err)
+    }
+
+    const filepathsChanged = res.map((fileMeta) => fileMeta.filename)
+    updatePrWithLabels(options, resolveLabels(filepathsChanged))
+  })
+}
+
+function updatePrWithLabels (options, labels) {
+  // no need to request github if we didn't resolve any labels
+  if (!labels.length) {
+    return
+  }
+
+  fetchExistingLabels(options, (err, existingLabels) => {
+    if (err) {
+      return
+    }
+
+    const mergedLabels = labels.concat(existingLabels)
+
+    githubClient.issues.edit({
+      user: options.owner,
+      repo: options.repo,
+      number: options.prId,
+      labels: mergedLabels
+    }, (err) => {
+      if (err) {
+        return console.error(`! ${prInfoStr(options)} Error while adding labels`, err)
+      }
+
+      console.log(`! ${prInfoStr(options)} Added labels: ${labels}`)
+    })
+  })
+}
+
+function fetchExistingLabels (options, cb) {
+  githubClient.issues.getIssueLabels({
+    user: options.owner,
+    repo: options.repo,
+    number: options.prId
+  }, (err, res) => {
+    if (err) {
+      console.error(`! ${prInfoStr(options)} Error while fetching existing labels`, err)
+      return cb(err)
+    }
+
+    const existingLabels = res.map((labelMeta) => labelMeta.name)
+    cb(null, existingLabels)
+  })
+}
+
+function prInfoStr (options) {
+  return `${options.owner}/${options.repo}/#${options.prId}`
+}
+
+exports.resolveLabelsThenUpdatePr = resolveLabelsThenUpdatePr

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Node.js GitHub Bot",
   "scripts": {
     "start": "node server.js",
-    "test": "standard"
+    "test": "tap test/*.test.js && standard",
+    "test:watch": "nodemon -q -x 'npm test'"
   },
   "engines": {
     "node": ">= 4.2.0"
@@ -22,6 +23,8 @@
   },
   "devDependencies": {
     "eventsource": "^0.2.1",
-    "standard": "^6.0.7"
+    "nodemon": "^1.9.1",
+    "standard": "^6.0.7",
+    "tap": "^5.7.1"
   }
 }

--- a/scripts/node-subsystem-label.js
+++ b/scripts/node-subsystem-label.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const debug = require('debug')('node_subsystem_label')
+
+const nodeRepo = require('../lib/node-repo')
+
+module.exports = function (app) {
+  app.on('pull_request.opened', handlePrCreated)
+
+  function handlePrCreated (event, owner, repo) {
+    const prId = event.number
+    // subsystem labelling is for node core only
+    if (repo !== 'node') return
+
+    debug(`/${owner}/${repo}/pull/${prId} opened`)
+    // by not hard coding the owner repo to nodejs/node here,
+    // we can test these this script in a different repo than
+    // *actual* node core as long as the repo is named "node"
+    nodeRepo.resolveLabelsThenUpdatePr({ owner, repo, prId })
+  }
+}

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ require('dotenv').load({ silent: true })
 const glob = require('glob')
 const express = require('express')
 const bodyParser = require('body-parser')
+
 const captureRaw = (req, res, buffer) => { req.raw = buffer }
 
 const app = express()

--- a/test/node-labels.test.js
+++ b/test/node-labels.test.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const tap = require('tap')
+
+const nodeLabels = require('../lib/node-labels')
+
+tap.test('label: "test" when only ./test/ files has been changed', (t) => {
+  const labels = nodeLabels.resolveLabels([
+    'test/debugger/test-debugger-pid.js',
+    'test/debugger/test-debugger-repl-break-in-module.js',
+    'test/debugger/test-debugger-repl-term.js'
+  ])
+
+  t.same(labels, ['test'])
+
+  t.end()
+})
+
+tap.test('label: "c++" when ./src/* has been changed', (t) => {
+  const labels = nodeLabels.resolveLabels([
+    'src/async-wrap.h',
+    'src/async-wrap.cc'
+  ])
+
+  t.same(labels, ['c++'])
+
+  t.end()
+})
+
+//
+// Planned tests to be resolved later
+//
+
+tap.test('label: "repl" when ./lib/repl.js has been changed', (t) => {
+  const labels = nodeLabels.resolveLabels([
+    'lib/repl.js',
+    'test/debugger/test-debugger-pid.js',
+    'test/debugger/test-debugger-repl-break-in-module.js',
+    'test/debugger/test-debugger-repl-term.js'
+  ])
+
+  t.same(labels, ['repl'], { todo: true })
+
+  t.end()
+})
+
+tap.test('label: "lib / src" when more than 5 sub-systems has been changed', (t) => {
+  const labels = nodeLabels.resolveLabels([
+    'lib/assert.js',
+    'lib/dns.js',
+    'lib/repl.js',
+    'lib/process.js',
+    'src/async-wrap.cc',
+    'lib/module.js'
+  ])
+
+  t.same(labels, ['lib / src'], { todo: true })
+
+  t.end()
+})


### PR DESCRIPTION
Very much a work in progress ATM, just wanted to get this out there for public scrutiny and work on it the next couple of days.

**Goals**
- [x] lists appropriate labels for any PR on `/labels/#PR-NUM`
- [x] adds labels to created PR's

**UPDATE** In the discussion below, we've decided to only resolve `c++` and `test` labels at first, then add more labels in later iterations of this.

Refs #1 