### PR TITLE
Connect to SSE server when SSE_RELAY set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,54 @@
 # Node.js GitHub Bot
 
-What's this?? ATM an experiment to see if a bot could be helpful for the Node.js project, to automate all the things!
-
-## Get it started
-
-It's required to have a [GitHub API token](https://github.com/blog/1509-personal-api-tokens) and [Travis token](https://blog.travis-ci.com/2013-01-28-token-token-token/) before starting the bot.
-
-```bash
-$ GITHUB_TOKEN=X TRAVIS_CI_TOKEN=Z npm start
-```
-
-### Create a GitHub access token
-
-Go to your own profile settings page and [generate a personal access token](https://github.com/settings/tokens/new). After clicking the **Generate token** button you're presented with the token you should put in `$GITHUB_TOKEN` when starting the bot.
-
-### Retrieving your Travis token
-
-Your Travis token is visible on [your profile](https://travis-ci.org/profile) page, by clicking the "show token" link.
+The Node.js Foundation's uses this bot to help manage [the repositories of the GitHub organization](https://github.com/nodejs). 
+It executes [scripts](https://github.com/nodejs-github-bot/github-bot/tree/master/scripts) in response to events that are 
+pushed to it via GitHub webhooks. All [repositories](https://github.com/nodejs) use this same bot instance and need to 
+have the same webhook url & secret configured. Org-wide webhooks are not allow.
 
 ## Contributing
 
 Please do, contributions are more than welcome!
+
+### Environment Variables
+
+- **`GITHUB_TOKEN`**<br>
+  The [GitHub API token](https://github.com/blog/1509-personal-api-tokens) for your account (or bot account) that will be 
+  used to make API calls to GitHub. The account must have proper access to perform the actions required by your script.
+- **`GITHUB_WEBHOOK_SECRET`**<br>
+  The webhook secret that Githib signs the POSTed payloads with. This is created when the webhook is defined. The default 
+  is `hush-hush`.
+- **`TRAVIS_CI_TOKEN`**<br>
+  For scripts that communicate with Travis CI. Your Travis token is visible on [your profile](https://travis-ci.org/profile) 
+  page, by clicking the "show token" link. Also See: https://blog.travis-ci.com/2013-01-28-token-token-token
+
+
+### Developing Locally
+
+The bot will try to load a `.env` file at the root of the project if it exists to set environment varaibles. You will need 
+to create one similar to this:
+
+```
+GITHUB_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TRAVIS_CI_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+SSE_RELAY=https://hook-relay.herokuapp.com
+```
+
+**Note the additional `SSE_RELAY` variable:**
+When developing locally, it is difficult to setup a GitHub webhook 
+pointing to the computer you are developing on. An easy workaround is to set the `SSE_RELAY` to the url of 
+[a SSE relay server](https://github.com/williamkapke/hook-relay) that will send the GitHub events via 
+[Server Sent Events](http://www.html5rocks.com/en/tutorials/eventsource/basics/) instead.
+
+You can use the [TestOrgPleaseIgnore](https://github.com/TestOrgPleaseIgnore) GitHub Organization, to test 
+your changes. Actions performed on the repos there will be sent to 
+[the SSE Relay](https://github.com/williamkapke/hook-relay).
+
+The `GITHUB_WEBHOOK_SECRET` environment variable is not required when using the relay.
+
+**Run the bot:**
+```bash
+$ npm start
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 The Node.js Foundation's uses this bot to help manage [the repositories of the GitHub organization](https://github.com/nodejs). 
 It executes [scripts](https://github.com/nodejs-github-bot/github-bot/tree/master/scripts) in response to events that are 
-pushed to it via GitHub webhooks. All [repositories](https://github.com/nodejs) use this same bot instance and need to 
-have the same webhook url & secret configured. Org-wide webhooks are not allow.
+pushed to it via GitHub webhooks. All [repositories](https://github.com/nodejs) that use this bot have the same webhook url & 
+secret configured (there is only 1 bot instance). Org-wide webhooks are not allow.
 
 ## Contributing
 
@@ -49,6 +49,14 @@ The `GITHUB_WEBHOOK_SECRET` environment variable is not required when using the 
 ```bash
 $ npm start
 ```
+
+When developing a script, it is likely that you will only want to run the script(s) that you are working on. You may 
+pass an additional [glob](https://www.npmjs.com/package/glob) argument to specify which scripts to run.
+
+```bash
+$ npm start ./scripts/my-new-event-handler.js
+```
+
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "travis-ci": "^2.1.0"
   },
   "devDependencies": {
+    "eventsource": "^0.2.1",
     "standard": "^6.0.7"
   }
 }

--- a/server.js
+++ b/server.js
@@ -21,3 +21,21 @@ const port = process.env.PORT || 3000
 app.listen(port, () => {
   console.log('Example app listening on port', port)
 })
+
+if (process.env.SSE_RELAY) {
+  const EventSource = require('eventsource')
+  var es = new EventSource(process.env.SSE_RELAY)
+  es.onmessage = (e) => {
+    try {
+      const data = JSON.parse(e.data)
+      if (!data.action) return
+
+      var source = data.repository ? data.repository.full_name : data.organization.login
+      console.log('event@%s: %s', source, data.action)
+
+      app.emit(data.action, data)
+    } catch (e) {
+      console.error(e)
+    }
+  }
+}


### PR DESCRIPTION
I [threw together a relay server](https://github.com/williamkapke/hook-relay) to help with developing the bot. The way it works is you set a `SSE_RELAY` env variable to the url of the relay server that will relay you the events from Github. This removes the need for devs to setup a webhook & routing that points to their local machine... or even worse: deploying to their host, over & over again!

### Overview:
![SSE Workflow](https://cloud.githubusercontent.com/assets/739813/14413483/92821f1e-ff30-11e5-9a6f-14067f64cb3f.png)
**EDIT**: In the picture above, the repos would likely be `TestOrgPleaseIgnore` not `nodejs`.

### Check it out for yourself:
[SSE is a very simple/lightweight protocol](https://html.spec.whatwg.org/multipage/comms.html#server-sent-events) that is perfect for this. It even is supported by modern browsers so you can connect and see the raw event stream.
1) Open: https://hook-relay.herokuapp.com/
2) Go to: https://github.com/TestOrgPleaseIgnore/nodejs.org/pull/1
3) Add a label or a comment...or whatever to cause an event.
4) Watch the output in the browser window.

