### PR TITLE
Find commit by PR when polling Travis builds

### DIFF
--- a/lib/pollTravis.js
+++ b/lib/pollTravis.js
@@ -22,77 +22,10 @@ githubClient.authenticate({
   token: process.env.GITHUB_TOKEN
 })
 
-exports.pollThenStatus = pollThenStatus
-
-function pollThenStatus (owner, repoName, prId) {
-  const prInfo = prInfoStr({ owner, repoName, prId })
-
-  // we have to figure out what type of Travis polling we should perform,
-  // either by PR #id (as for nodejs.org) or commit sha (for readable-stream)
-  travisClient.repos(owner, repoName).builds.get((err, res) => {
-    if (err) {
-      return console.error(`! ${prInfo} Error while retrieving initial builds`, err.stack)
-    }
-
-    const hasAnyPrBuilds = res.builds.some((build) => build.pull_request)
-
-    if (hasAnyPrBuilds) {
-      pollByPrThenComment(owner, repoName, prId)
-    } else {
-      pollByCommitThenStatus(owner, repoName, prId)
-    }
-  })
-}
+exports.pollThenStatus = pollByCommitThenStatus
 
 /**
- * When Travis CI picks up our PR's, we can poll and match builds
- * by their related PR #id.
- *
- * That's the case for nodejs.org.
- */
-function pollByPrThenComment (owner, repoName, prId, checkNumber) {
-  checkNumber = checkNumber || 1
-
-  const prInfo = prInfoStr({ owner, repoName, prId })
-  const createGhComment = createGhCommentFn({ owner, repoName, prId })
-
-  if (checkNumber > 100) {
-    console.warn(`* ${prInfo} Was not able to find matching build for PR, stopping poll now :(`)
-    return
-  }
-
-  travisClient.repos(owner, repoName).builds.get((err, res) => {
-    if (err) {
-      return console.error(`! ${prInfo} Error while retrieving builds`, err.stack)
-    }
-
-    const lastBuildForPr = res.builds.find((build) => build.pull_request_number === prId)
-
-    if (lastBuildForPr) {
-      const lastState = lastBuildForPr.state
-
-      if (lastState === 'passed') {
-        return createGhComment(`[Travis build passed](https://travis-ci.org/${owner}/${repoName}/builds/${lastBuildForPr.id}) :+1:`)
-      } else if (lastState === 'failed') {
-        return createGhComment(`[Travis build failed](https://travis-ci.org/${owner}/${repoName}/builds/${lastBuildForPr.id}) :-1:`)
-      } else if (~['created', 'started'].indexOf(lastState)) {
-        console.log(`* ${prInfo} "${lastState}" build found, will do check #${checkNumber + 1} in 30 seconds`)
-      } else {
-        return console.log(`* ${prInfo} Unknown build state: "${lastState}", stopping polling`)
-      }
-    } else {
-      console.warn(`! ${prInfo} Was not able to find matching build, will do check #${checkNumber + 1} in 30 seconds`)
-    }
-
-    setTimeout(pollByPrThenComment, 30 * 1000, owner, repoName, prId, checkNumber + 1)
-  })
-}
-
-/**
- * When Travis CI *doesn't* pick up our PR's, we have to poll and match builds
- * by the last commit SHA of the related PR.
- *
- * This is the case for readable-stream.
+ * Poll and match builds by the last commit SHA of the related PR.
  */
 function pollByCommitThenStatus (owner, repoName, prId) {
   const prInfo = prInfoStr({ owner, repoName, prId })
@@ -155,24 +88,6 @@ function pollTravisBuildBySha (options, checkNumber) {
 
     setTimeout(pollTravisBuildBySha, 30 * 1000, options, checkNumber + 1)
   })
-}
-
-function createGhCommentFn (options) {
-  const prInfo = prInfoStr(options)
-
-  return (message) => {
-    githubClient.issues.createComment({
-      user: options.owner,
-      repo: options.repoName,
-      number: options.prId,
-      body: message
-    }, (err, res) => {
-      if (err) {
-        return console.error(`! ${prInfo} Error while creating GitHub comment`, err.stack)
-      }
-      console.log(`* ${prInfo} Github comment created`)
-    })
-  }
 }
 
 function createGhStatusFn (options) {

--- a/lib/pollTravis.js
+++ b/lib/pollTravis.js
@@ -49,6 +49,7 @@ function pollTravisBuildBySha (options, checkNumber) {
   const createGhStatus = createGhStatusFn(options)
   const prInfo = prInfoStr(options)
   const shaToMatch = options.lastSha
+  const prToMatch = options.prId
 
   checkNumber = checkNumber || 1
 
@@ -62,7 +63,9 @@ function pollTravisBuildBySha (options, checkNumber) {
       return console.error(`! ${prInfo} Got error when retrieving Travis builds`, err.stack)
     }
 
-    const matchingCommit = res.commits.find((commit) => commit.sha === shaToMatch)
+    const matchingCommit = res.commits.find((commit) => {
+      return commit.sha === shaToMatch || commit.pull_request_number === prToMatch
+    })
     if (!matchingCommit) {
       console.warn(`! ${prInfo} Travis hasn't picked up last commit yet, will do check #${checkNumber + 1} in 30 seconds`)
       return setTimeout(pollTravisBuildBySha, 30 * 1000, options, checkNumber + 1)


### PR DESCRIPTION
We've been struggling with PR builds being triggered with commit SHA we have no reference of - seems like some kind of meta merge commit made by GitHub. Therefore our effort of matching builds by the actual commit SHA from PRs doesn't always work.

There's a trivial change included here in 05af2ed which also tries to match commits by their related PR. Fingers crossed this is what we need.

+ reverting the revert (deleting the commenting code)

P.S. this is currently deployed to production.