### PR TITLE
Also match commits by their commited date when polling Travis

### DIFF
--- a/lib/pollTravis.js
+++ b/lib/pollTravis.js
@@ -39,17 +39,25 @@ function pollByCommitThenStatus (owner, repoName, prId) {
       return console.error(`! ${prInfo} Got error when retrieving GitHub commits for PR`, err.stack)
     }
 
-    const lastSha = commitMetas.pop().sha
-    pollTravisBuildBySha({ owner, repoName, prId, lastSha })
-    console.log(`* ${prInfo} Started polling Travis for build by commit ${lastSha.substr(0, 7)}`)
+    const lastCommitMeta = commitMetas.pop()
+    const lastCommit = {
+      sha: lastCommitMeta.sha,
+      date: lastCommitMeta.commit.committer.date
+    }
+
+    pollTravisBuildBySha({ owner, repoName, prId, lastCommit })
+    console.log(`* ${prInfo} Started polling Travis for build by commit ${lastCommit.sha.substr(0, 7)}`)
   })
 }
 
 function pollTravisBuildBySha (options, checkNumber) {
   const createGhStatus = createGhStatusFn(options)
   const prInfo = prInfoStr(options)
-  const shaToMatch = options.lastSha
-  const prToMatch = options.prId
+  const toMatch = {
+    sha: options.lastCommit.sha,
+    date: options.lastCommit.date,
+    prId: options.prId
+  }
 
   checkNumber = checkNumber || 1
 
@@ -64,7 +72,10 @@ function pollTravisBuildBySha (options, checkNumber) {
     }
 
     const matchingCommit = res.commits.find((commit) => {
-      return commit.sha === shaToMatch || commit.pull_request_number === prToMatch
+      const matchesShaOrPr = commit.sha === toMatch.sha || commit.pull_request_number === toMatch.prId
+      const matchesCommitDate = commit.committed_at === toMatch.date
+
+      return matchesCommitDate && matchesShaOrPr
     })
     if (!matchingCommit) {
       console.warn(`! ${prInfo} Travis hasn't picked up last commit yet, will do check #${checkNumber + 1} in 30 seconds`)
@@ -100,14 +111,14 @@ function createGhStatusFn (options) {
     githubClient.statuses.create({
       user: options.owner,
       repo: options.repoName,
-      sha: options.lastSha,
+      sha: options.lastCommit.sha,
       target_url: `https://travis-ci.org/${options.owner}/${options.repoName}/builds/${travisId}`,
       context: 'Travis CI via nodejs-github-bot',
       state: state,
       description: message
     }, (err, res) => {
       if (err) {
-        return console.error(`! ${prInfo} Error while updating GitHub PR status`, err.stack)
+        return console.error(`! ${prInfo} Error while updating GitHub PR status`, err)
       }
       console.log(`* ${prInfo} Github PR status updated`)
     })


### PR DESCRIPTION
As seen in the nodejs.org repo today https://github.com/nodejs/nodejs.org/pull/647#issuecomment-208940672, the bot might be tripped into reporting status for the previous build/commit.

This aims to fix that issue by always matching commits by their date as well as commit sha or PR number.

Refs #22