### PR TITLE
Use globs to load scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dotenv": "^2.0.0",
     "express": "^4.13.4",
     "github": "^0.2.4",
+    "glob": "^7.0.3",
     "travis-ci": "^2.1.0"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@
 
 require('dotenv').load({ silent: true })
 
+const glob = require('glob')
 const express = require('express')
 const bodyParser = require('body-parser')
 const captureRaw = (req, res, buffer) => { req.raw = buffer }
@@ -11,8 +12,7 @@ app.use(bodyParser.json({ verify: captureRaw }))
 require('./lib/github-events.js')(app)
 
 // load all the files in the scripts folder
-require('fs').readdirSync('./scripts').forEach((file) => {
-  file = './scripts/' + file
+glob.sync(process.argv[2] || './scripts/**/*.js').forEach((file) => {
   console.log('loading:', file)
   require(file)(app)
 })


### PR DESCRIPTION
The (current) initial version just tries to load all files in the `./scripts` directory. When developing, you want to target just the script you're working on.

This change allows a `glob` argument to be passed in to specify which file(s) to try to load. If it isn't specified, it defaults to `./scripts/**/*.js`.
