### PR TITLE
move sse code to github-events

### DIFF
--- a/lib/github-events.js
+++ b/lib/github-events.js
@@ -17,16 +17,16 @@ module.exports = (app) => {
     }
 
     const signature = req.headers['x-hub-signature']
+    const data = req.body
+    data.action = data.action ? event + '.' + data.action : event
+
     if (!signature || signature !== sign(secret, req.raw)) {
       res.writeHead(401, 'Invalid Signature')
-      console.error('! event@%s: %s - invalid signature, returning 401', source, data.action)
+      console.error('! event@%s: %s - invalid signature, returning 401', data.repository.full_name, data.action)
       return res.end()
     }
 
     res.end()
-
-    const data = req.body
-    data.action = data.action ? event + '.' + data.action : event
 
     emit(data)
   })

--- a/lib/github-events.js
+++ b/lib/github-events.js
@@ -1,5 +1,5 @@
 const crypto = require('crypto')
-const debug = require('debug')('github')
+const debug = require('debug')('github-events')
 
 const secret = process.env.GITHUB_WEBHOOK_SECRET || 'hush-hush'
 
@@ -28,13 +28,31 @@ module.exports = (app) => {
     const data = req.body
     data.action = data.action ? event + '.' + data.action : event
 
-    var source = data.repository ? data.repository.full_name : data.organization.login
-    console.log('event@%s: %s', source, data.action)
-
-    if (debug.enabled) {
-      debug(JSON.stringify(data, null, 2))
-    }
-
-    app.emit(data.action, data)
+    emit(data)
   })
+
+  if (process.env.SSE_RELAY) {
+    const EventSource = require('eventsource')
+    var es = new EventSource(process.env.SSE_RELAY)
+    es.onmessage = (e) => {
+      try {
+        const data = JSON.parse(e.data)
+        if (!data.action) return
+
+        emit(data)
+      } catch (e) {
+        console.error(e)
+      }
+    }
+  }
+
+  function emit (data) {
+    const repo = data.repository
+    const org = repo.owner.login || data.organization.login
+
+    console.log('event@%s/%s: %s', org, repo.name, data.action)
+    debug(data)
+
+    app.emit(data.action, data, org, repo.name, data.sender.login)
+  }
 }

--- a/server.js
+++ b/server.js
@@ -21,21 +21,3 @@ const port = process.env.PORT || 3000
 app.listen(port, () => {
   console.log('Example app listening on port', port)
 })
-
-if (process.env.SSE_RELAY) {
-  const EventSource = require('eventsource')
-  var es = new EventSource(process.env.SSE_RELAY)
-  es.onmessage = (e) => {
-    try {
-      const data = JSON.parse(e.data)
-      if (!data.action) return
-
-      var source = data.repository ? data.repository.full_name : data.organization.login
-      console.log('event@%s: %s', source, data.action)
-
-      app.emit(data.action, data)
-    } catch (e) {
-      console.error(e)
-    }
-  }
-}


### PR DESCRIPTION
Having the events emitting in 2 places is not good. The SSE relay is only `github-events` related code - so it makes sense to move it to the `github-events.js` file.

Also, I am now emitting the org, repo, and sender names since will be needed by most listeners.
