### PR TITLE
Fix for bad node core PR exclusive labels.

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -25,8 +25,9 @@ function resolveLabels (filepathsChanged) {
 }
 
 function matchExclusiveSubSystem (filepathsChanged) {
+  const isExclusive = filepathsChanged.every(matchesAnExclusiveLabel)
   const labels = matchSubSystemsByRegex(exclusiveLabelsMap, filepathsChanged)
-  return labels.length === 1 ? labels : []
+  return (isExclusive && labels.length === 1) ? labels : []
 }
 
 function matchAllSubSystem (filepathsChanged) {
@@ -73,6 +74,10 @@ function mappedSubSystemForFile (labelsMap, filepath) {
 
 function withoutUndefinedValues (label) {
   return label !== undefined
+}
+
+function matchesAnExclusiveLabel (filepath) {
+  return mappedSubSystemForFile(exclusiveLabelsMap, filepath) !== undefined
 }
 
 exports.resolveLabels = resolveLabels

--- a/test/node-labels.test.js
+++ b/test/node-labels.test.js
@@ -27,6 +27,20 @@ tap.test('no labels: when ./test/ and ./doc/ files has been changed', (t) => {
   t.end()
 })
 
+// This ensures older mislabelling issues doesn't happen again
+// https://github.com/nodejs/node/pull/6432
+// https://github.com/nodejs/node/pull/6448
+tap.test('no labels: when ./test/ and ./lib/ files has been changed', (t) => {
+  const labels = nodeLabels.resolveLabels([
+    'lib/assert.js',
+    'test/parallel/test-assert.js'
+  ])
+
+  t.same(labels, [])
+
+  t.end()
+})
+
 tap.test('label: "doc" when only ./doc/ files has been changed', (t) => {
   const labels = nodeLabels.resolveLabels([
     'doc/api/fs.md',


### PR DESCRIPTION
This fixes some bad labelling by ensuring that *every* file affected in the PR actually matches an exclusive label when we're checking for exclusive labels.

Refs https://github.com/nodejs/node/pull/6448 https://github.com/nodejs/node/pull/6432
Closes https://github.com/nodejs-github-bot/github-bot/issues/33