### PR TITLE
Created smoketest verifying the bot starts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ language: node_js
 node_js:
   - 4
   - 5
+  - 6

--- a/app.js
+++ b/app.js
@@ -1,0 +1,21 @@
+'use strict'
+
+require('dotenv').load({ silent: true })
+
+const glob = require('glob')
+const express = require('express')
+const bodyParser = require('body-parser')
+
+const captureRaw = (req, res, buffer) => { req.raw = buffer }
+
+const app = express()
+app.use(bodyParser.json({ verify: captureRaw }))
+require('./lib/github-events')(app)
+
+// load all the files in the scripts folder
+glob.sync(process.argv[2] || './scripts/**/*.js').forEach((file) => {
+  console.log('loading:', file)
+  require(file)(app)
+})
+
+module.exports = app

--- a/lib/github-client.js
+++ b/lib/github-client.js
@@ -14,7 +14,7 @@ const githubClient = new GitHub({
 
 githubClient.authenticate({
   type: 'oauth',
-  token: process.env.GITHUB_TOKEN
+  token: process.env.GITHUB_TOKEN || 'invalid-placeholder-token'
 })
 
 module.exports = githubClient

--- a/lib/github-events.js
+++ b/lib/github-events.js
@@ -28,25 +28,10 @@ module.exports = (app) => {
 
     res.end()
 
-    emit(data)
+    app.emitGhEvent(data)
   })
 
-  if (process.env.SSE_RELAY) {
-    const EventSource = require('eventsource')
-    var es = new EventSource(process.env.SSE_RELAY)
-    es.onmessage = (e) => {
-      try {
-        const data = JSON.parse(e.data)
-        if (!data.action) return
-
-        emit(data)
-      } catch (e) {
-        console.error(e)
-      }
-    }
-  }
-
-  function emit (data) {
+  app.emitGhEvent = function emitGhEvent (data) {
     const repo = data.repository
     const org = repo.owner.login || data.organization.login
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "eventsource": "^0.2.1",
     "nodemon": "^1.9.1",
+    "request": "^2.72.0",
     "standard": "^6.0.7",
     "tap": "^5.7.1"
   }

--- a/scripts/ping.js
+++ b/scripts/ping.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = function (app) {
+  app.get('/ping', (req, res) => {
+    res.end('pong')
+  })
+}

--- a/test/ping.test.js
+++ b/test/ping.test.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tap = require('tap')
+const request = require('request')
+
+const app = require('../app')
+
+tap.test('GET /ping responds with status 200 / "pong"', (t) => {
+  const server = app.listen()
+  const port = server.address().port
+  const url = `http://localhost:${port}/ping`
+
+  t.plan(3)
+  t.tearDown(() => server.close())
+
+  request(url, (err, res, body) => {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.equal(res.body, 'pong')
+  })
+})


### PR DESCRIPTION
As a means of being more confident deploying the bot automatically to production upon merge to master, this ensures the bot at least starts as planned and responds on a trivial GET request.

Did some refactoring to make the bot more testable, most noticeably extracted the `server.listen()` part into it's own file so the `app` could be tested in isolation with explicit control over the server/listening part for testing purposes. Plus not always starting the SSE relay client (which we don't need while testing).

Refs https://github.com/nodejs/build/issues/404.