### PR TITLE
Log job name when proxying Jenkins -> GH status

### DIFF
--- a/lib/push-jenkins-update.js
+++ b/lib/push-jenkins-update.js
@@ -23,9 +23,9 @@ function createGhStatusFn (options) {
       description: message
     }, (err, res) => {
       if (err) {
-        return console.error(`! ${prInfo} Error while updating Jenkins / GitHub PR status`, err)
+        return console.error(`! ${prInfo} Error while updating Jenkins / GitHub PR status to '${state}' for ${options.context}`, err)
       }
-      console.log(`* ${prInfo} Jenkins / Github PR status updated to '${state}'`)
+      console.log(`* ${prInfo} Jenkins / Github PR status updated to '${state}' for ${options.context}`)
     })
   }
 }


### PR DESCRIPTION
Currently we're not logging *which* Jenkins job is trying to push GitHub status updates. That information would be very valuable when debugging.

/cc @jbergstroem 