### PR TITLE
Validate POST payloads from Jenkins

### DIFF
--- a/lib/push-jenkins-update.js
+++ b/lib/push-jenkins-update.js
@@ -2,7 +2,7 @@
 
 const githubClient = require('./github-client')
 
-function pushJenkinsUpdate (options, build) {
+function push (options, build) {
   const statusOpts = extendWithBuildData(options, build)
   const createGhStatus = createGhStatusFn(statusOpts)
 
@@ -43,4 +43,10 @@ function prInfoStr (options) {
   return `${options.owner}/${options.repoName}/${shortSha}`
 }
 
-module.exports = pushJenkinsUpdate
+function validate (payload) {
+  const isString = (param) => typeof (payload[param]) === 'string'
+  return ['identifier', 'status', 'message', 'commit', 'url'].every(isString)
+}
+
+exports.validate = validate
+exports.push = push

--- a/scripts/node-jenkins-status.js
+++ b/scripts/node-jenkins-status.js
@@ -4,7 +4,13 @@ const pushJenkinsUpdate = require('../lib/push-jenkins-update')
 
 module.exports = function (app) {
   app.post('/node/jenkins', (req, res) => {
-    pushJenkinsUpdate({
+    const isValid = pushJenkinsUpdate.validate(req.body)
+
+    if (!isValid) {
+      return res.status(400).end('Invalid payload')
+    }
+
+    pushJenkinsUpdate.push({
       owner: 'nodejs',
       repoName: 'node'
     }, req.body)

--- a/test/_fixtures/invalid-payload.json
+++ b/test/_fixtures/invalid-payload.json
@@ -1,0 +1,5 @@
+{
+    "identifier": "test/osx",
+    "status": "pending",
+    "url": "https://ci.nodejs.org/job/node-test-commit-osx/3157/"
+}

--- a/test/push-jenkins-update.test.js
+++ b/test/push-jenkins-update.test.js
@@ -52,6 +52,23 @@ tap.test('Forwards payload provided in incoming POST to GitHub status API', (t) 
     })
 })
 
+tap.test('Responds with 400 / "Bad request" when incoming request has invalid payload', (t) => {
+  const fixture = readFixture('invalid-payload.json')
+
+  // don't care about the results, just want to prevent any HTTP request ever being made
+  nock('https://api.github.com')
+
+  t.plan(1)
+
+  supertest(app)
+    .post('/node/jenkins')
+    .send(fixture)
+    .expect(400, 'Invalid payload')
+    .end((err, res) => {
+      t.equal(err, null)
+    })
+})
+
 function ignoreQueryParams (pathAndQuery) {
   return url.parse(pathAndQuery, true).pathname
 }


### PR DESCRIPTION
So far there's been cases when sha, or other required fields of the payload has been missing, but the bot has willingly tried to proxy it as well as responding with a misleading 201 status code.

This at least does some trivial validation and tells you right away if the payload is seen invalid.