### PR TITLE
Refactor labels to use Regex-keyed Maps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 sudo: false
 language: node_js
 node_js:
-  - 4
-  - 5
   - 6

--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -1,24 +1,25 @@
 'use strict'
 
 // order of entries in this map *does* matter for the resolved labels
-const subSystemLabelsMap = {
+// earlier entries override later entries
+const subSystemLabelsMap = new Map([
   // don't want to label it a c++ update when we're "only" bumping the Node.js version
-  'c++': /^src\/(?!node_version\.h)/,
+  [/^src\/(?!node_version\.h)/, 'c++'],
   // meta is a very specific label for things that are policy and or meta-info related
-  'meta': /^([A-Z]+$|CODE_OF_CONDUCT|ROADMAP|WORKING_GROUPS|GOVERNANCE|CHANGELOG|\.mail|\.git.+)/,
+  [/^([A-Z]+$|CODE_OF_CONDUCT|ROADMAP|WORKING_GROUPS|GOVERNANCE|CHANGELOG|\.mail|\.git.+)/, 'meta'],
   // things that edit top-level .md files are always a doc change
-  'doc': /^\w+\.md$/,
+  [/^\w+\.md$/, 'doc'],
   // libuv needs an explicit mapping, as the ordinary /deps/ mapping below would
   // end up as libuv changes labeled with "uv" (which is a non-existing label)
-  'libuv': /^deps\/uv\//,
-  '$1': /^deps\/([^/]+)/
-}
+  [/^deps\/uv\//, 'libuv'],
+  [/^deps\/([^/]+)/, '$1']
+])
 
-const exclusiveLabelsMap = {
-  test: /^test\//,
-  doc: /^doc\//,
-  benchmark: /^benchmark\//
-}
+const exclusiveLabelsMap = new Map([
+  [/^test\//, 'test'],
+  [/^doc\//, 'doc'],
+  [/^benchmark\//, 'benchmark']
+])
 
 function resolveLabels (filepathsChanged) {
   const exclusiveLabels = matchExclusiveSubSystem(filepathsChanged)
@@ -54,30 +55,23 @@ function matchSubSystemsByRegex (rxLabelsMap, filepathsChanged) {
 }
 
 function mappedSubSystemForFile (labelsMap, filepath) {
-  return Object.keys(labelsMap).map((labelName) => {
-    const rxForLabel = labelsMap[labelName]
-    const matches = rxForLabel.exec(filepath)
+  for (const [regex, label] of labelsMap) {
+    const matches = regex.exec(filepath)
 
-    // return undefined when subsystem regex didn't match,
-    // we'll filter out these values with the .filter() below
     if (matches === null) {
-      return undefined
+      continue
     }
 
     // label names starting with $ means we want to extract a matching
     // group from the regex we've just matched against
-    if (labelName.startsWith('$')) {
-      const wantedMatchGroup = labelName.substr(1)
+    if (label.startsWith('$')) {
+      const wantedMatchGroup = label.substr(1)
       return matches[wantedMatchGroup]
     }
 
     // use label name as is when label doesn't look like a regex matching group
-    return labelName
-  }).filter(withoutUndefinedValues)[0]
-}
-
-function withoutUndefinedValues (label) {
-  return label !== undefined
+    return label
+  }
 }
 
 function matchesAnExclusiveLabel (filepath) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:watch": "nodemon -q -x 'npm test'"
   },
   "engines": {
-    "node": ">= 4.2.0"
+    "node": ">= 6.0.0"
   },
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
Allows for more extensibility where labels may be the same. (e.g. more than one `$1` mapping)

Requires Node.js v6.0.0+ for the destructing in the `for of` loop.

cc @phillipj 