### PR TITLE
labels: fix string_decoder labeling

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -19,7 +19,6 @@ const subSystemLabelsMap = new Map([
   /* JS subsystems */
   // Oddities first
   [/^lib\/(punycode|\w+\/freelist|sys\.js)/, ''], // TODO: ignore better?
-  [/^lib\/string_decoder/, 'buffer'],
   [/^lib\/constants\.js$/, 'lib / src'],
   [/^lib\/_(debug_agent|debugger)\.js$/, 'debugger'],
   [/^lib(\/\w+)?\/(_)?link(ed)?list/, 'timers'],
@@ -37,7 +36,7 @@ const jsSubsystemList = [
   'debugger', 'assert', 'buffer', 'child_process', 'cluster', 'console',
   'crypto', 'dgram', 'dns', 'domain', 'events', 'fs', 'http', 'https', 'module',
   'net', 'os', 'path', 'process', 'querystring', 'readline', 'repl', 'stream',
-  'timers', 'tls', 'tty', 'url', 'util', 'v8', 'vm', 'zlib'
+  'string_decoder', 'timers', 'tls', 'tty', 'url', 'util', 'v8', 'vm', 'zlib'
 ]
 
 const exclusiveLabelsMap = new Map([

--- a/test/node-js-subsystem-labels.test.js
+++ b/test/node-js-subsystem-labels.test.js
@@ -25,7 +25,6 @@ tap.test('label: lib oddities', (t) => {
     'lib/_tls_wrap.js',
     'lib/constants.js',
     'lib/punycode.js', // ignored
-    'lib/string_decoder.js',
     'lib/sys.js', // ignored
     'lib/internal/freelist.js', // ignored
     'lib/internal/process',
@@ -38,16 +37,15 @@ tap.test('label: lib oddities', (t) => {
   const labels = nodeLabels.resolveLabels(libFiles, false)
 
   t.same(labels, [
-    'debugger',  // _debug_agent
-    'http',      // _http_*
-    'timers',    // linklist
-    'stream',    // _stream_*
-    'tls',       // _tls_*
-    'lib / src', // constants
-    'buffer',    // string_decoder
-    'process',   // internal/process/
-    'net',       // socket_list
-    'tools'      // v8_prof_*
+    'debugger',       // _debug_agent
+    'http',           // _http_*
+    'timers',         // linklist
+    'stream',         // _stream_*
+    'tls',            // _tls_*
+    'lib / src',      // constants
+    'process',        // internal/process/
+    'net',            // socket_list
+    'tools'           // v8_prof_*
   ])
 
   t.end()
@@ -96,6 +94,7 @@ tap.test('label: lib normal without "lib / src" limiting', (t) => {
     'lib/readline.js',
     'lib/repl.js',
     'lib/stream.js',
+    'lib/string_decoder.js',
     'lib/timers.js',
     'lib/tls.js',
     'lib/tty.js',


### PR DESCRIPTION
`buffer` is really separate from `string_decoder` (the latter actually uses the former's functionality), so update the bot's labeling mechanism.