### PR TITLE
Fix invalid PR argument in Travis poller

### DIFF
--- a/scripts/display-travis-status.js
+++ b/scripts/display-travis-status.js
@@ -9,9 +9,10 @@ module.exports = function (app) {
   // Pull Request updates
   app.on('pull_request.synchronize', handlePrUpdate)
 
-  function handlePrUpdate (event, owner, repo, pr) {
+  function handlePrUpdate (event, owner, repo) {
     if (!~enabledRepos.indexOf(repo)) return
 
+    const pr = event.number
     const options = { owner, repo, pr, logger: event.logger }
 
     debug(`/${owner}/${repo}/pull/${pr} opened`)


### PR DESCRIPTION
Seen in the logs:

```
12:18:09.203 ERROR bot: Got error when retrieving GitHub commits for PR (req_id=.., pr=nodejs/nodejs.org/#754, action=pull_request.opened)
    err: {
      "code": "400",
      "status": "Bad Request",
      "message": "Invalid value for parameter 'number': lpinca"
    }
```

Bug was introduced in d5fdb5d5a5a6c9705e32524efdb4530f390e73b8.