### PR TITLE
labels: add subsystem label for API doc

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -41,6 +41,8 @@ const jsSubsystemList = [
 
 const exclusiveLabelsMap = new Map([
   [/^test\//, 'test'],
+  // automatically tag subsystem-specific API doc changes
+  [/^doc\/api\/(\w+).md$/, ['doc', '$1']],
   [/^doc\//, 'doc'],
   [/^benchmark\//, 'benchmark']
 ])
@@ -53,10 +55,29 @@ function resolveLabels (filepathsChanged, limitLib = true) {
           : matchAllSubSystem(filepathsChanged, limitLib)
 }
 
+function hasAllSubsystems (arr) {
+  return arr.every((val) => {
+    return jsSubsystemList.includes(val)
+  })
+}
+
 function matchExclusiveSubSystem (filepathsChanged) {
   const isExclusive = filepathsChanged.every(matchesAnExclusiveLabel)
-  const labels = matchSubSystemsByRegex(exclusiveLabelsMap, filepathsChanged)
-  return (isExclusive && labels.length === 1) ? labels : []
+  var labels = matchSubSystemsByRegex(exclusiveLabelsMap, filepathsChanged)
+  // if there are multiple API doc changes, do not apply subsystem tags for now
+  if (isExclusive &&
+      labels.includes('doc') &&
+      labels.length > 2) {
+    const nonDocLabels = labels.filter((val) => {
+      return val !== 'doc'
+    })
+    if (hasAllSubsystems(nonDocLabels)) {
+      labels = ['doc']
+    } else {
+      labels = []
+    }
+  }
+  return isExclusive ? labels : []
 }
 
 function matchAllSubSystem (filepathsChanged, limitLib) {
@@ -68,27 +89,30 @@ function matchSubSystemsByRegex (rxLabelsMap, filepathsChanged, limitLib) {
   const jsLabelCount = []
   // by putting matched labels into a map, we avoid duplicate labels
   const labelsMap = filepathsChanged.reduce((map, filepath) => {
-    const mappedSubSystem = mappedSubSystemForFile(rxLabelsMap, filepath)
+    const mappedSubSystems = mappedSubSystemsForFile(rxLabelsMap, filepath)
 
-    if (!mappedSubSystem) {
+    if (!mappedSubSystems) {
       // short-circuit
       return map
     }
 
-    if (limitLib && jsSubsystemList.includes(mappedSubSystem)) {
-      if (jsLabelCount.length >= 4) {
-        for (const jsLabel of jsLabelCount) {
-          delete map[jsLabel]
+    for (var i = 0; i < mappedSubSystems.length; ++i) {
+      const mappedSubSystem = mappedSubSystems[i]
+      if (limitLib && jsSubsystemList.includes(mappedSubSystem)) {
+        if (jsLabelCount.length >= 4) {
+          for (const jsLabel of jsLabelCount) {
+            delete map[jsLabel]
+          }
+          map['lib / src'] = true
+          // short-circuit
+          return map
+        } else {
+          jsLabelCount.push(mappedSubSystem)
         }
-        map['lib / src'] = true
-        // short-circuit
-        return map
-      } else {
-        jsLabelCount.push(mappedSubSystem)
       }
-    }
 
-    map[mappedSubSystem] = true
+      map[mappedSubSystem] = true
+    }
 
     return map
   }, {})
@@ -96,7 +120,7 @@ function matchSubSystemsByRegex (rxLabelsMap, filepathsChanged, limitLib) {
   return Object.keys(labelsMap)
 }
 
-function mappedSubSystemForFile (labelsMap, filepath) {
+function mappedSubSystemsForFile (labelsMap, filepath) {
   for (const [regex, label] of labelsMap) {
     const matches = regex.exec(filepath)
 
@@ -104,20 +128,27 @@ function mappedSubSystemForFile (labelsMap, filepath) {
       continue
     }
 
-    // label names starting with $ means we want to extract a matching
-    // group from the regex we've just matched against
-    if (label.startsWith('$')) {
-      const wantedMatchGroup = label.substr(1)
-      return matches[wantedMatchGroup]
-    }
-
-    // use label name as is when label doesn't look like a regex matching group
-    return label
+    const ret = []
+    const labels = Array.isArray(label) ? label : [label]
+    labels.forEach((label) => {
+      // label names starting with $ means we want to extract a matching
+      // group from the regex we've just matched against
+      if (label.startsWith('$')) {
+        const wantedMatchGroup = label.substr(1)
+        label = matches[wantedMatchGroup]
+      }
+      if (!label) {
+        return
+      }
+      // use label name as is when label doesn't look like a regex matching group
+      ret.push(label)
+    })
+    return ret
   }
 }
 
 function matchesAnExclusiveLabel (filepath) {
-  return mappedSubSystemForFile(exclusiveLabelsMap, filepath) !== undefined
+  return mappedSubSystemsForFile(exclusiveLabelsMap, filepath) !== undefined
 }
 
 exports.resolveLabels = resolveLabels

--- a/test/node-js-subsystem-labels.test.js
+++ b/test/node-js-subsystem-labels.test.js
@@ -130,3 +130,25 @@ tap.test('label: lib internals without "lib / src" limiting', (t) => {
 
   t.end()
 })
+
+tap.test('label: add subsystem when ./doc/api/<subsystem>.md has been changed', (t) => {
+  const labels = nodeLabels.resolveLabels([
+    'doc/api/fs.md'
+  ], false)
+
+  t.same(labels, ['doc', 'fs'])
+
+  t.end()
+})
+
+tap.test('label: only "doc" with multiple API doc files changed', (t) => {
+  const labels = nodeLabels.resolveLabels([
+    'doc/api/fs.md',
+    'doc/api/stream.md'
+  ], false)
+
+  t.same(labels, ['doc'])
+
+  t.end()
+})
+

--- a/test/node-labels.test.js
+++ b/test/node-labels.test.js
@@ -95,7 +95,7 @@ tap.test('label: "v8" when ./deps/v8/ files has been changed', (t) => {
   t.end()
 })
 
-tap.test('label: "libuv" when ./deps/ub/ files has been changed', (t) => {
+tap.test('label: "libuv" when ./deps/uv/ files has been changed', (t) => {
   const labels = nodeLabels.resolveLabels([
     'deps/uv/src/fs-poll.c'
   ])


### PR DESCRIPTION
This is only done if a PR is *only* modifying a single subsystem's API documentation.

Feel free to reject this and implement it some other way if you don't like how I did this, I just figured it'd be better to submit some kind of PR instead of just creating a feature request issue.