### PR TITLE
labels: add "build" label

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -10,7 +10,8 @@ const subSystemLabelsMap = new Map([
   // things that edit top-level .md files are always a doc change
   [/^\w+\.md$/, 'doc'],
   // different variants of *Makefile and build files
-  [/^(tools\/)?(Makefile|BSDmakefile)$/, 'build'],
+  [/^(tools\/)?(Makefile|BSDmakefile|create_android_makefiles)$/, 'build'],
+  [/^tools\/(install.py|genv8constants.py|getnodeversion.py|js2c.py|utils.py|configure.d\/.*)$/, 'build'],
   [/^(configure|node.gyp|common.gypi)$/, 'build'],
 
   /* Dependencies */

--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -9,6 +9,9 @@ const subSystemLabelsMap = new Map([
   [/^([A-Z]+$|CODE_OF_CONDUCT|ROADMAP|WORKING_GROUPS|GOVERNANCE|CHANGELOG|\.mail|\.git.+)/, 'meta'],
   // things that edit top-level .md files are always a doc change
   [/^\w+\.md$/, 'doc'],
+  // different variants of *Makefile and build files
+  [/^(tools\/)?(Makefile|BSDmakefile)$/, 'build'],
+  [/^(configure|node.gyp|common.gypi)$/, 'build'],
 
   /* Dependencies */
   // libuv needs an explicit mapping, as the ordinary /deps/ mapping below would

--- a/test/node-build-label.test.js
+++ b/test/node-build-label.test.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const tap = require('tap')
+
+const nodeLabels = require('../lib/node-labels')
+
+tap.test('label: "build" when build related files has been changed', (t) => {
+  const buildRelatedFiles = [
+    'configure',
+    'node.gyp',
+    'common.gypi',
+    'BSDmakefile',
+    'Makefile',
+    'tools/Makefile'
+  ]
+
+  buildRelatedFiles.forEach((filepath) => {
+    const labels = nodeLabels.resolveLabels([ filepath ])
+
+    t.same(labels, ['build'], filepath + ' got "build" label')
+  })
+
+  t.end()
+})
+
+tap.test('labels: not "build" when Makefile in ./deps has been changed', (t) => {
+  const labels = nodeLabels.resolveLabels([
+    'deps/v8/Makefile'
+  ])
+
+  t.notOk(labels.includes('build'))
+
+  t.end()
+})

--- a/test/node-build-label.test.js
+++ b/test/node-build-label.test.js
@@ -11,7 +11,14 @@ tap.test('label: "build" when build related files has been changed', (t) => {
     'common.gypi',
     'BSDmakefile',
     'Makefile',
-    'tools/Makefile'
+    'tools/Makefile',
+    'tools/install.py',
+    'tools/create_android_makefiles',
+    'tools/genv8constants.py',
+    'tools/getnodeversion.py',
+    'tools/js2c.py',
+    'tools/utils.py',
+    'tools/configure.d/nodedownload.py'
   ]
 
   buildRelatedFiles.forEach((filepath) => {


### PR DESCRIPTION
This adds support for the `build` label as described in #31.

@jbergstroem in https://github.com/nodejs/node/pull/6247#issuecomment-212211532 you mentioned other stuff in `tools/` aswell . Feel free to provide some examples, and I'll have a look.