### PR TITLE
labels: prevent deps from getting "lib / src" label

### DIFF
--- a/lib/node-labels.js
+++ b/lib/node-labels.js
@@ -104,7 +104,7 @@ function matchSubSystemsByRegex (rxLabelsMap, filepathsChanged, limitLib) {
 
     for (var i = 0; i < mappedSubSystems.length; ++i) {
       const mappedSubSystem = mappedSubSystems[i]
-      if (limitLib && jsSubsystemList.includes(mappedSubSystem)) {
+      if (limitLib && hasJsSubsystemChanges(filepathsChanged, mappedSubSystem)) {
         if (jsLabelCount.length >= 4) {
           for (const jsLabel of jsLabelCount) {
             delete map[jsLabel]
@@ -124,6 +124,11 @@ function matchSubSystemsByRegex (rxLabelsMap, filepathsChanged, limitLib) {
   }, {})
 
   return Object.keys(labelsMap)
+}
+
+function hasJsSubsystemChanges (filepathsChanged, mappedSubSystem) {
+  const hasLibChanges = filepathsChanged.some((filepath) => filepath.startsWith('lib/'))
+  return hasLibChanges && jsSubsystemList.includes(mappedSubSystem)
 }
 
 function mappedSubSystemsForFile (labelsMap, filepath) {

--- a/test/node-labels.test.js
+++ b/test/node-labels.test.js
@@ -157,6 +157,21 @@ tap.test('label: "lib / src" when 5 or more JS sub-systems have been changed', (
   t.end()
 })
 
+// https://github.com/nodejs/node/pull/7488 wrongfully labelled with "lib / src"
+tap.test('label: not "lib / src" when only deps have been changed', (t) => {
+  const labels = nodeLabels.resolveLabels([
+    'deps/v8/test/cctest/interpreter/bytecode_expectations/ArrayLiterals.golden',
+    'deps/v8/test/cctest/interpreter/bytecode_expectations/ArrayLiteralsWide.golden',
+    'deps/v8/test/cctest/interpreter/bytecode_expectations/AssignmentsInBinaryExpression.golden',
+    'deps/v8/test/cctest/interpreter/bytecode_expectations/BasicBlockToBoolean.golden',
+    'deps/v8/test/cctest/interpreter/bytecode_expectations/BasicLoops.golden'
+  ])
+
+  t.same(labels, ['v8'])
+
+  t.end()
+})
+
 tap.test('label: "JS sub-systems when less than 5 sub-systems have changed', (t) => {
   const labels = nodeLabels.resolveLabels([
     'lib/assert.js',


### PR DESCRIPTION
This prevents changes in `deps/` from getting labelled `lib / src` as seen in https://github.com/nodejs/node/pull/7488.

@Fishrock123 as you implemented `lib / src` in the first place, does this seem good to you?

Closes #52 